### PR TITLE
Remove `Debug` derive from DynamicRendering

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -64,7 +64,7 @@ impl Default for Options {
 
 /// `dynamic-rendering` feature related params
 #[cfg(feature = "dynamic-rendering")]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct DynamicRendering {
     pub color_attachment_format: vk::Format,
     pub depth_attachment_format: Option<vk::Format>,


### PR DESCRIPTION
Either the crate needs to expose a feature "debug" that enables "ash/debug" and toggles debug implementations or, what I've done in this PR, we can just remove the Debug implementation from DynamicRendering which is a fairly uninteresting struct anyway. It does go against https://rust-lang.github.io/api-guidelines/debuggability.html#all-public-types-implement-debug-c-debug. 

BREAKING CHANGE