### PR TITLE
Allow passing stencil attachment format for dynamic rendering

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -68,6 +68,7 @@ impl Default for Options {
 pub struct DynamicRendering {
     pub color_attachment_format: vk::Format,
     pub depth_attachment_format: Option<vk::Format>,
+    pub stencil_attachment_format: Option<vk::Format>,
 }
 
 /// Vulkan renderer for egui.

--- a/src/renderer/vulkan.rs
+++ b/src/renderer/vulkan.rs
@@ -212,6 +212,9 @@ pub(crate) fn create_vulkan_pipeline(
         if let Some(depth_attachment_format) = dynamic_rendering.depth_attachment_format {
             rendering_info = rendering_info.depth_attachment_format(depth_attachment_format);
         }
+        if let Some(stencil_attachment_format) = dynamic_rendering.stencil_attachment_format {
+            rendering_info = rendering_info.stencil_attachment_format(stencil_attachment_format);
+        }
         rendering_info
     };
     #[cfg(feature = "dynamic-rendering")]


### PR DESCRIPTION
This allows re-using an already existing render begin that has a stencil attachment.

BREAKING_CHANGE